### PR TITLE
Fix Beautify Anki in latest Anki version (2.1.49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/) 
 <a title="Rate on AnkiWeb" href="add link"><img src="https://glutanimate.com/logos/ankiweb-rate.svg"></a> <a title="Buy me a coffee :)" href="https://ko-fi.com/B0B51L5RI"><img src="https://img.shields.io/badge/ko--fi-contribute-%23579ebd.svg"></a>
 
+> ⚠️ THIS IS A POORLY PATCHED VERSION OF THE ORIGINAL ADDON TO WORK ON NEWER ANKI (TESTED ON 2.1.49)
+
 ![](https://gblobscdn.gitbook.com/assets%2F-M8bIX1VrL7AvQYQHy62%2F-M8bU0Cd_2bCQQXOfPpF%2F-M8bYnu8pXKuV1GQ4lC-%2Fezgif.com-crop.gif?alt=media&token=d2c9feb9-118f-48ea-90da-d2f6e145e6c0)
   
  

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Beautify Anki is an [Anki](https://apps.ankiweb.net/) addon that attempts to giv
 
 ## 📥 Download 
 <b>Be sure to read [THIS](https://beautify-anki.shorouk.dev/before-install) first before installing this addon.</b><br>
-Download the latest version from [Ankiweb](https://ankiweb.net/shared/info/1150874988) or select a version manually from [here](https://github.com/my-Anki/Beautify-Anki/releases)
+Download the latest version from [Ankiweb](https://ankiweb.net/shared/info/1150874988) or select a version manually from [here](https://github.com/fylux/Beautify-Anki/releases)
 
 
 ## ⚠️ Disclaimer
-This is a beta version that has only been tested on Anki 2.1.22. and 2.1.26 It probably conflicts with other addons that do similar things [(check the list of known conflicting addons)](https://beautify-anki.shorouk.dev/before-install). For feature request and bug report please post an a [new issue](https://github.com/my-Anki/Beautify-Anki/issues) 
+This is a beta version that has only been tested on Anki 2.1.22. and 2.1.26 It probably conflicts with other addons that do similar things [(check the list of known conflicting addons)](https://beautify-anki.shorouk.dev/before-install). For feature request and bug report please post an a [new issue](https://github.com/fylux/Beautify-Anki/issues) 
 
 
 ## ⚙️ Configuration and Customization 

--- a/__init__.py
+++ b/__init__.py
@@ -71,18 +71,18 @@ def on_webview_will_set_content (web_content: aqt.webview.WebContent,  context: 
     if  isinstance(context, aqt.overview.Overview):        
         web_content.css.append (base+"/user_files/assets/css/overview.css")
         web_content.css.remove("overview.css")
-        web_content.css.remove("webview.css")
+        web_content.css.remove("css/webview.css")
         web_content.js.append (base+"/user_files/assets/js/plotly-latest.min.js")  
 
     # add css and js to deck browser
     if  isinstance(context, aqt.deckbrowser.DeckBrowser):        
         web_content.css.append (base+"/user_files/assets/css/deckbrowser.css")
-        web_content.css.remove("deckbrowser.css")
+        web_content.css.remove("css/deckbrowser.css")
     
     # add css and js to deck browser bottom bar
     if isinstance (context , ( aqt.deckbrowser.DeckBrowserBottomBar,aqt.overview.OverviewBottomBar)):        
         web_content.css.append (base+"/user_files/assets/css/bottombar.css")
-        web_content.css.remove("webview.css")
+        web_content.css.remove("css/webview.css")
 
         if NIHGT_MODE:         
             web_content.css.append (base+"/user_files/assets/css/bottombar_dark.css")

--- a/deck_overview.py
+++ b/deck_overview.py
@@ -508,16 +508,16 @@ def finishedMsg(self, _old) -> str:
         "<div class='deck-desc finish-msg animate__animated animate__rubberBand' style='background-color:{THEME[large-areas-color]};'>".format(THEME=THEME)
         + _("Congratulations! You have finished this deck for now.")
         + "<br></div>"
-        + self._nextDueMsg()
+        #+ self._nextDueMsg()
     )
 
 
 def nextDueMsg(self, _old) -> str:
     line = []
 
-    learn_msg = self.next_learn_msg()
-    if learn_msg:
-        line.append(learn_msg)
+    #learn_msg = self.next_learn_msg()
+    #if learn_msg:
+    #    line.append(learn_msg)
 
     # the new line replacements are so we don't break translations
     # in a point release

--- a/reviewer.py
+++ b/reviewer.py
@@ -63,8 +63,8 @@ time = %(time)d;
     )
 
 def showAnswerButton(self):
-    if not self.typeCorrect:
-        self.bottom.web.setFocus()
+    #if not self.typeCorrect:
+    #    self.bottom.web.setFocus()
     middle = """
 <span class=stattxt>%s</span><br>
 <button style='color: {THEME[buttons-label-color]} ;background-color:{THEME[buttons-color]}' class='btn btn-sm' title="%s" id=ansbut onclick='pycmd("ans");'>%s</button>""".format(THEME=THEME) % (

--- a/reviewer.py
+++ b/reviewer.py
@@ -63,8 +63,8 @@ time = %(time)d;
     )
 
 def showAnswerButton(self):
-    #if not self.typeCorrect:
-    #    self.bottom.web.setFocus()
+    if not self.typeCorrect:
+        self.mw.web.setFocus()
     middle = """
 <span class=stattxt>%s</span><br>
 <button style='color: {THEME[buttons-label-color]} ;background-color:{THEME[buttons-color]}' class='btn btn-sm' title="%s" id=ansbut onclick='pycmd("ans");'>%s</button>""".format(THEME=THEME) % (
@@ -78,7 +78,7 @@ def showAnswerButton(self):
         % middle
     )
     if self.card.shouldShowTimer():
-        maxTime = self.card.timeLimit() / 1000
+        maxTime = self.card.time_limit() / 1000
     else:
         maxTime = 0
     self.bottom.web.eval("showQuestion(%s,%d);" % (json.dumps(middle), maxTime))


### PR DESCRIPTION
I have tried fix the add-on by simply spotting what part of the code was crashing and fixing it accordingly. I could trigger 3 different crashes and they were fixed in the following ways:

- self.bottom.web.setFocus() was producing inifinite recursion. Use self.mw.web.setFocus() instead.
- self._nextDueMsg() and self.next_learn_msg() have been deprecated after the TS + Rust rewrite (ankitects/anki@e568525)
- Apparently now webview.css and deckbrowser.css are in the css/ folder

Overall, these are very hacky fixes because in ankitects/anki@e568525 most of the logic that this add-on uses was rewritten so to fix the add-on further a complete rewrite would be required. It might be that there are more crashes which this fix does not cover since I was the only tester.

Tested locally on Windows 10, Anki 2.1.49.

PS: Thanks to @datphan310 for the reviewer.py fix. Before I was just naively commenting the code.